### PR TITLE
loosen bounds to support ghc-8.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,14 +13,15 @@ jobs:
     runs-on: ubuntu-16.04
     strategy:
       matrix:
-        ghc: ["8.8.1"]
-        cabal: ["3.0"]
+        ghc: ["8.8.1","8.10.4"]
+        cabal: ["3.2"]
 
     steps:
     - uses: actions/checkout@v2
       if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/main'
 
-    - uses: actions/setup-haskell@v1
+    - uses: haskell/actions/setup@v1
+      id: setup-haskell-cabal
       name: Setup Haskell
       with:
         ghc-version: ${{ matrix.ghc }}
@@ -28,7 +29,7 @@ jobs:
 
     - uses: actions/cache@v1
       with:
-        path: ~/.cabal/store
+        path: ${{ steps.setup-haskell-cabal.outputs.cabal-store }}
         key: ${{ runner.os }}-${{ matrix.ghc }}-cabal
 
     - name: Build

--- a/policeman.cabal
+++ b/policeman.cabal
@@ -21,8 +21,8 @@ source-repository head
   location:            https://github.com/kowainik/policeman.git
 
 common common-options
-  build-depends:       base ^>= 4.13.0.0
-                     , relude ^>= 0.6.0.0
+  build-depends:       base >= 4.13.0.0 && < 4.15
+                     , relude >= 0.6.0.0 && < 0.8
 
   mixins:              base hiding (Prelude)
                      , relude (Relude as Prelude)
@@ -83,7 +83,7 @@ library
                      , dir-traverse ^>= 0.2.2.2
                      , directory ^>= 1.3
                      , filepath ^>= 1.4
-                     , ghc ^>= 8.8
+                     , ghc >= 8.8 && < 9.0
                      , gitrev ^>= 1.3
                      , mtl ^>= 2.2.2
                      , optparse-applicative ^>= 0.15

--- a/policeman.cabal
+++ b/policeman.cabal
@@ -21,7 +21,7 @@ source-repository head
   location:            https://github.com/kowainik/policeman.git
 
 common common-options
-  build-depends:       base >= 4.13.0.0 && < 4.15
+  build-depends:       base >= 4.13.0.0 && < 4.16
                      , relude >= 0.6.0.0 && < 0.8
 
   mixins:              base hiding (Prelude)
@@ -83,7 +83,7 @@ library
                      , dir-traverse ^>= 0.2.2.2
                      , directory ^>= 1.3
                      , filepath ^>= 1.4
-                     , ghc >= 8.8 && < 9.0
+                     , ghc >= 8.8 && < 9.1
                      , gitrev ^>= 1.3
                      , mtl ^>= 2.2.2
                      , optparse-applicative ^>= 0.15


### PR DESCRIPTION
Fixes #57. This only bumps the minimal amount of dependencies to make it build with ghc-8.10, I didn't bother to check if any other upper bounds could also be bumped.