### PR TITLE
don't get confused by cabal.project files

### DIFF
--- a/src/Policeman/Hie.hs
+++ b/src/Policeman/Hie.hs
@@ -21,6 +21,11 @@ createHieFiles :: FilePath -> IO [HieFile]
 createHieFiles projectDir = do
     curDir <- getCurrentDirectory
     setCurrentDirectory projectDir
+
+    -- make sure cabal isn't confused by any other "cabal.project"
+    -- file in a parent directory
+    writeFile "cabal.project" "packages: ."
+
     "cabal" ["clean"]
     "cabal"
         [ "v2-build"

--- a/src/Policeman/Hie.hs
+++ b/src/Policeman/Hie.hs
@@ -24,6 +24,7 @@ createHieFiles projectDir = do
 
     -- make sure cabal isn't confused by any other "cabal.project"
     -- file in a parent directory
+    -- See discussion: https://github.com/kowainik/policeman/issues/52
     writeFile "cabal.project" "packages: ."
 
     "cabal" ["clean"]


### PR DESCRIPTION
Fixes #52.

When run from a folder `<my-project>` which contains a cabal.project
file, policeman will fail with the following message:

    cabal: No targets given and there is no package in the current
    directory. [...]

In fact, there is a package in the current directory, which policeman
just created at `<my-project>/.policeman-evidence/<my-project>-<previous-version>`.
Unfortunately, since that newly-created directory is not listed in
`<my-project>/cabal.project`, it is ignored by cabal.

The solution is to create a competing file at
`<my-project>/.policeman-evidence/<my-project>-<previous-version>/cabal.project`.
cabal will find that file first, and since that file does list the
current directory, cabal will accept to build it.